### PR TITLE
Allow outputting of true/false/nil values via a config option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /log/
 /tmp/
 /tags
+.byebug_history
 
 # Package and dependency caches
 /.bundle

--- a/README.md
+++ b/README.md
@@ -235,6 +235,27 @@ logger.log my_url: "https://user:password@example.com"
 
 Note that returning nil value will make l2meter omit the field completely.
 
+### "Compacting" values
+
+By default l2meter will treat key-value pairs where the value is `true`, `false` or `nil` differently. `false` and `nil` values will cause the whole pair to be omitted, `true` will cause just the key to be output:
+
+```ruby
+logger.log foo: "hello", bar: true  # => foo=hello bar
+logger.log foo: "hello", bar: false # => foo=hello
+logger.log foo: "hello", bar: nil   # => foo=hello
+```
+
+When the option is disabled, the full pairs are emitted:
+
+```ruby
+config.compact_values = false
+logger.log foo: "hello", bar: true  # => foo=hello bar=true
+logger.log foo: "hello", bar: false # => foo=hello bar=false
+logger.log foo: "hello", bar: nil   # => foo=hello bar=null
+```
+
+Note that "null" is output in the `nil` case.
+
 ## Silence
 
 There's a way to temporary silence the log emitter. This might be useful for

--- a/lib/l2meter/configuration.rb
+++ b/lib/l2meter/configuration.rb
@@ -16,6 +16,7 @@ module L2meter
       @output = $stdout
       @float_precision = 4
       @context = nil
+      @compact_values = true
     end
 
     def format_keys(&block)
@@ -28,6 +29,14 @@ module L2meter
 
     def sort=(value)
       @sort = !!value
+    end
+
+    def compact_values?
+      @compact_values
+    end
+
+    def compact_values=(value)
+      @compact_values = !!value
     end
 
     def context

--- a/lib/l2meter/emitter.rb
+++ b/lib/l2meter/emitter.rb
@@ -4,6 +4,8 @@ module L2meter
   class Emitter
     attr_reader :configuration
 
+    BARE_VALUE_SENTINEL = Object.new.freeze
+
     def initialize(configuration: Configuration.new)
       @configuration = configuration
     end
@@ -202,6 +204,8 @@ module L2meter
         key
       when FalseClass, NilClass
         nil
+      when value == BARE_VALUE_SENTINEL
+        key
       else
         value = format_value(value)
         "#{key}=#{value}"
@@ -253,7 +257,7 @@ module L2meter
       {}.tap do |result|
         args.each do |arg|
           next if arg.nil?
-          arg = Hash[arg, true] unless Hash === arg
+          arg = Hash[arg, BARE_VALUE_SENTINEL] unless Hash === arg
           arg.each do |key, value|
             result[key] = value
           end

--- a/lib/l2meter/emitter.rb
+++ b/lib/l2meter/emitter.rb
@@ -160,7 +160,7 @@ module L2meter
     end
 
     def source_context
-      {source: configuration.source}
+      configuration.source ? {source: configuration.source} : {}
     end
 
     def resolved_contexts

--- a/lib/l2meter/emitter.rb
+++ b/lib/l2meter/emitter.rb
@@ -199,10 +199,10 @@ module L2meter
     end
 
     def format_token(key, value)
-      case value
-      when TrueClass
+      case
+      when value == true && configuration.compact_values?
         key
-      when FalseClass, NilClass
+      when !value && configuration.compact_values?
         nil
       when value == BARE_VALUE_SENTINEL
         key
@@ -222,6 +222,8 @@ module L2meter
         format_time_value(value)
       when Array
         value.map(&method(:format_value)).join(",")
+      when nil
+        "null"
       else
         format_value(value.to_s)
       end

--- a/spec/emitter_spec.rb
+++ b/spec/emitter_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe L2meter::Emitter do
       expect(output).to eq("foo=bar\n")
     end
 
-    it "skips key-value pairs where valus is nil" do
+    it "skips key-value pairs where value is nil" do
       subject.log(foo: :bar, fizz: nil)
       expect(output).to eq("foo=bar\n")
     end

--- a/spec/emitter_spec.rb
+++ b/spec/emitter_spec.rb
@@ -29,6 +29,16 @@ RSpec.describe L2meter::Emitter do
       expect(output).to eq("foo=bar\n")
     end
 
+    it "skips key-value pairs where value is false" do
+      subject.log(foo: :bar, fizz: false)
+      expect(output).to eq("foo=bar\n")
+    end
+
+    it "logs key only where value is true" do
+      subject.log(foo: :bar, fizz: true)
+      expect(output).to eq("foo=bar fizz\n")
+    end
+
     it "logs key-value pairs with string as keys" do
       subject.log("foo" => "bar")
       expect(output).to eq("foo=bar\n")

--- a/spec/emitter_spec.rb
+++ b/spec/emitter_spec.rb
@@ -39,6 +39,30 @@ RSpec.describe L2meter::Emitter do
       expect(output).to eq("foo=bar fizz\n")
     end
 
+    context "when compact_values config option is disabled" do
+      before { configuration.compact_values = false }
+
+      it "outputs nil values as 'null'" do
+        subject.log(foo: :bar, fizz: nil)
+        expect(output).to eq("foo=bar fizz=null\n")
+      end
+
+      it "outputs false values" do
+        subject.log(foo: :bar, fizz: false)
+        expect(output).to eq("foo=bar fizz=false\n")
+      end
+
+      it "outputs true values" do
+        subject.log(foo: :bar, fizz: true)
+        expect(output).to eq("foo=bar fizz=true\n")
+      end
+
+      it "still outputs bare values" do
+        subject.log(:tag1, :tag2)
+        expect(output).to eq("tag1 tag2\n")
+      end
+    end
+
     it "logs key-value pairs with string as keys" do
       subject.log("foo" => "bar")
       expect(output).to eq("foo=bar\n")


### PR DESCRIPTION
(Throwing this out as a draft PR for now because I couldn't decide on some things and wanted to see if anyone else had opinions before I went to the effort of implementing it properly. If there are no comments after 24 hours I'll decide the things myself, clean it up and mark it ready for review.)

This PR allows configuration of the behaviour around how key/value pairs are output where the value is `true`, `false` or `nil`. At the moment the behaviour is:

```ruby
log(foo: true)  # -> "foo"
log(foo: false) # -> ""
log(foo: nil)   # -> ""
```

Enabling the configuration option changes it to this:

```ruby
log(foo: true)  # -> "foo=true"
log(foo: false) # -> "foo=false"
log(foo: nil)   # -> "foo=null"
```

This allows users of this library to have these values be output when they want to, for whatever reason. When enabled it matches the behaviour of https://github.com/go-logfmt/logfmt. As there is no logfmt spec (that I'm aware of, anyway - please let me know if I missed something!) it seems acceptable to allow this configuration.

(I also fixed a few other small things - see the commits.)