### PR TITLE
Fix Ruby deprecation for Proc.new

### DIFF
--- a/lib/l2meter/configuration.rb
+++ b/lib/l2meter/configuration.rb
@@ -39,9 +39,9 @@ module L2meter
       @compact_values = !!value
     end
 
-    def context
-      if block_given?
-        @context = Proc.new
+    def context(&block)
+      if block
+        @context = block
       else
         @context
       end


### PR DESCRIPTION
The warning was:

```
lib/l2meter/configuration.rb:44: warning: Capturing the given block using Proc.new is deprecated; use `&block` instead
```

Instead we use the optional `&block` argument.