### PR TITLE
Bring back `#disable!` support

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,10 +256,9 @@ logger.log foo: "hello", bar: nil   # => foo=hello bar=null
 
 Note that "null" is output in the `nil` case.
 
-## Silence
+## Silencing
 
-There's a way to temporary silence the log emitter. This might be useful for
-tests for example.
+To temporary silence the log emitter, during tests, for example:
 
 ```ruby
 logger.silence do
@@ -276,17 +275,23 @@ The typical setup for RSpec might look like this:
 ```ruby
 RSpec.configure do |config|
   config.around :each do |example|
-    MyLogger.silence &example
+    MyLogger.silence(&example)
   end
 end
 ```
 
 Note that silence method will only suppress logging in the current thread.
-It'll still produce output if you fire up a new thread. To silence it
-completely, use `disable!` method. This will completely silence the logger
-across all threads.
+It'll still produce output if you fire up a new thread.
+To silence it completely, use `#disable!` method.
+This will completely silence the logger across all threads.
 
 ```ruby
 # spec/spec_helper.rb
 MyLogger.disable!
+```
+
+It can be re-enabled via `#enable!`
+
+```ruby
+MyLogger.enable!
 ```

--- a/spec/emitter_spec.rb
+++ b/spec/emitter_spec.rb
@@ -764,5 +764,39 @@ RSpec.describe L2meter::Emitter do
         )
       end
     end
+
+    describe "#disable!" do
+      after do |example|
+        emitter.enable!
+      end
+
+      it "affects all threads" do
+        emitter.disable!
+
+        1_000.times do
+          emitter.log(thread: :main, line: 1)
+        end
+
+        disabled_thread_b = Thread.new {
+          1_000.times do
+            emitter.log(thread: :b, line: 2)
+          end
+        }
+
+        disabled_thread_c = Thread.new {
+          1_000.times do
+            emitter.log(thread: :c, line: 3)
+          end
+        }
+
+        [
+          disabled_thread_b,
+          disabled_thread_c
+        ].each(&:join)
+
+        output.lines
+        expect(output.lines).to be_empty
+      end
+    end
   end
 end


### PR DESCRIPTION
As part of #7 we lost the ability to totally disable the logger, across all threads. It's unclear if this was intentional, but I am guessing it was not. This will restore the behavior by returning a new `NullOutput` instance when trying to write while disabled. This might cause A LOT of object allocations, all with short lives. Hopefully. If so, we could consider some form of memoization of the instance.

Alternatively, we might choose that we don't actually want this feature. In which case we need to update the `README` and probably mention it in the `CHANGELOG`.

NOTE: This PR also introduces a `#enable!`, which would close #4.

Thoughts?
